### PR TITLE
Eric's Scripts

### DIFF
--- a/scripts/pull_fhircat.py
+++ b/scripts/pull_fhircat.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python
+
+from wstlr.hostfile import load_hosts_file
+from collections import defaultdict
+
+from ncpi_fhir_client.fhir_client import FhirClient
+
+from pathlib import Path
+import json
+
+import csv
+import sys
+from argparse import ArgumentParser, FileType
+
+import pdb
+
+class FhirDoc:
+    def __init__(self, resource, title, url):
+        self.title = title
+        self.url = url
+        self.subject = None
+        self.subject_ref = resource['subject']['reference']
+        self.specimen_ref = []
+        self.study_tag = resource['meta']['tag'][0]['code']
+        self.sex = ""
+        
+        if 'context' in resource:
+            self.specimen_ref = self.get_specimen_ref(resource.get("context"))
+
+    def get_specimen_ref(self, context):
+        specimen = []
+
+        for entry in context['related']:
+            specimen.append(entry['reference'])
+        return specimen
+
+    def get_tissue_display(self, client, ref):
+        response = client.get(ref)
+        if response.success():
+            if 'parent' in response.entries[0]:
+                return self.get_tissue_display(client, response.entries[0]['parent']['reference'])
+            else:
+                return response.entries[0]['type']['coding'][0]['display']
+
+    def collect_tissue_types(self, client):
+        tissues = set()
+
+        for specref in self.specimen_ref:
+            tissues.add(self.get_tissue_display(client, specref))
+
+        self.tissue_list = ", ".join(sorted(list(tissues)))
+
+
+
+    def get_patient(self, client):
+        response = client.get(self.subject_ref)
+        if response.success():
+            assert(len(response.entries) == 1)
+            self.collect_demographics(response.entries[0])
+            # self.full_urls['subject'] = response.entries[0]['fullUrl']
+            #self.raw['subject'] = response.entries[0]
+
+
+    def collect_demographics(self, resource):
+        if 'gender' in resource:
+            self.sex = resource['gender']
+
+    def load_other_resources(self, client):
+        self.get_patient(client)
+        self.collect_tissue_types(client)
+
+    @classmethod
+    def print_header(self, writer):
+        writer.writerow([
+            "filename",
+            "url",
+            "tissue_type",
+            "condition-disease",
+            "study_name",
+            "patient_sex"
+        ])
+
+    def write_row(self, writer):
+        writer.writerow([
+            tag,
+            self.title,
+            self.url,
+            self.tissue_list,
+            "TBD",
+            self.study_tag,
+            self.sex
+        ])
+
+host_config = load_hosts_file("fhir_hosts")
+# Just capture the available environments to let the user
+# make the selection at runtime
+env_options = sorted(host_config.keys())
+
+parser = ArgumentParser(description="Pull data from the specified FHIR server")
+parser.add_argument(
+    "-e",
+    "--env",
+    choices=env_options,
+    required=True,
+    help=f"Remote configuration to be used to access the FHIR server. If no environment is provided, the system will stop after generating the whistle output (no validation, no loading)",
+)
+
+args = parser.parse_args(sys.argv[1:])
+
+# First, pull the document references using the base query: 
+# DocumentReference?type=Gene-Expression,Gene-Expression-Quantifications&category=https://includedcc.org/fhir/code-systems/experimental_strategies|RNA-Seq&location:missing=false
+# I think this should work for all of the different fhir servers and datasets
+
+study_tags = {
+    "fhir-cat": ["GTEx"],
+    "qa-kf-inc": ["HTP", "DS-COG-ALL", "DS-PCGC", "DS360-CHD"],
+    "kf-fhir": [        
+        "SD_ZXJFFMEF",
+        "SD_46SK55A3",
+        "SD_PET7Q6F2",
+        "SD_46RR9ZR6",
+        "SD_Z6MWD3H0",
+        "SD_P445ACHV",
+        "SD_8Y99QZJJ",
+        "SD_6FPYJQBR",
+        "SD_YGVA0E1C",
+        "SD_DZTB5HRR",
+        "SD_BHJXBDQK",
+        "SD_VTTSHWV4",
+        "SD_DYPMEHHF",
+        "SD_0TYVY1TW",
+        "SD_ZFGDG5YS",
+        "SD_DZ4GPQX6",
+        "SD_RM8AFW0R",
+        "SD_R0EPRSGS",
+        "SD_W0V965XZ",
+        "SD_YNSSAPHE",
+        "SD_JWS3V24D",
+        "SD_PREASA7S",
+        "SD_NMVV8A1Y",
+        "SD_DK0KRWK8",
+        "SD_B8X3C1MX",
+        "SD_7NQ9151J",
+        "SD_9PYZAHHE",
+        "SD_1P41Z782",
+        "SD_HGHFVPFD",]
+}
+
+outdir = Path("output")
+outdir.mkdir(parents=True, exist_ok=True)
+fhir_client = FhirClient(host_config[args.env])
+
+documents = []
+
+_valid_filetypes = ['rsem.genes.results.gz', 'tpm.tsv.gz']
+def valid_filetype(title):
+    for vft in _valid_filetypes:
+        if vft in title:
+            return True
+    return False
+
+output_filename = f"{outdir}/{args.env}-fhircat.csv"
+with open(output_filename, 'wt') as outf:
+    writer = csv.writer(outf, delimiter=',', quotechar='"')
+    FhirDoc.print_header(writer)
+    for tag in study_tags[args.env]:
+        if args.env == "fhir-cat":
+            qry = f"DocumentReference?_tag={tag}&category=https://includedcc.org/fhir/code-systems/experimental_strategies|RNA-Seq&location:missing=false"
+        else:
+            qry = f"DocumentReference?_tag={tag}&type=Gene-Expression,Gene-Expression-Quantifications&category=https://includedcc.org/fhir/code-systems/experimental_strategies|RNA-Seq&location:missing=false"
+        docrefs = []
+        result = fhir_client.get(qry)
+        #pdb.set_trace()
+        if result.success():
+            for entry in result.entries:
+                resource = entry['resource']
+                    
+                #pdb.set_trace()
+                for content_entry in resource['content']:
+                    attachment = content_entry['attachment']
+                    title = attachment['title']
+                    url = attachment['url']
+
+                    if valid_filetype(title):
+                        doc = FhirDoc(resource, title, url)
+                        docrefs.append(doc)
+
+            #pdb.set_trace()
+            for doc in docrefs:
+                doc.load_other_resources(fhir_client)
+                doc.write_row(writer)

--- a/scripts/update_data.py
+++ b/scripts/update_data.py
@@ -1,0 +1,156 @@
+#!/usr/env python
+
+from csv import DictReader
+from pathlib import Path
+
+# wstlr is the name of the library from NCPI Whistler, the framework I've written
+# to automate the projection of CSV data into FHIR resourses using Google's 
+# Whistle language. I'm just borrowing the host configuration reader to simplify
+# the script. This file contains the various server authentication details and
+# endpoint information to permit simple targeting of resources (such as dev vs qa or
+# prod or even completely different types of FHIR servers)
+from wstlr.hostfile import load_hosts_file
+from collections import defaultdict
+
+# This is a wrapper for the KF Fhir API client. This uses the information from the host
+# selection made by the user to authenticate and interact with the FHIR server.
+from ncpi_fhir_client.fhir_client import FhirClient
+
+import csv
+import pdb
+
+# GTEX, include and kf are arbitrary keys initially used to point to the 
+# files where the original URIs to be explored were found (these were provided
+# by Robert). 
+input = {
+	"GTEX": "data/gtex.tsv",
+	"include": "data/include.tsv",
+	"kf": "data/kf.tsv"
+}
+
+# Just a cheat to move GTEX to the back since it takes far longer than the other two
+# combined to complete. Necessary to verify no additional errors were encountered with
+# data in either of the other two servers
+study_order = ["include", "kf", "GTEX"]
+
+# fhir-cat, prod-kf-inc and kf are keys from the hosts file associated with authentication
+# and endpoint details required for communicating with the remote servers.
+srvr = {
+	"GTEX": "fhir-cat",
+	"include": "prod-kf-inc",
+	"kf": "kf"
+}
+
+# Recursive function to crawl up the specimen tree to find the root node (probably Blood or
+# Saliva)
+def get_tissue_display(client, ref):
+	if 'Specimen' in ref:
+		response = client.get(ref)
+		if len(response.entries) > 0:
+			resource = response.entries[0]
+
+			if 'resource' in resource:
+				resource = resource['resource']
+
+			assert(response.success())
+			if 'parent' in response.entries[0]:
+				#pdb.set_trace()
+				# Is it safe to assume only one parent? For now, yes, but later that may not be true
+				return get_tissue_display(client, resource['parent'][0]['reference'])
+			else:
+				if 'type' not in resource:
+					pdb.set_trace()
+				return resource['type']['coding'][0]['display']
+
+		else:
+			print(f"Skipping specimen reference because the query returned {len(response.entries)}")
+
+# Boring wrapper to pull data into a uniform format regardless whether we are using a query
+# or specifying an exact resource			
+def get_resource(client, ref):
+	response = client.get(ref)
+
+	assert(response.success())
+	resource = response.entries[0]
+
+	if 'resource' in resource:
+		resource = resource['resource']
+
+	return resource
+
+# We can use the cheat if it exists, but not everything is linked with meta.tags so 
+# we crawl up to the ResearchSubject and get a reference for the study from there
+def get_study(client, patient_resource):
+	if 'tag' in patient_resource['meta']:
+		study_id = patient_resource['meta']['tag'][0]['code']
+		return get_resource(client, f"ResearchStudy?identifier={study_id}")
+	else:
+		research_subj = get_resource(client, f"ResearchSubject?patient=Patient/{patient_resource['id']}")
+		return get_resource(client, research_subj['study']['reference'])
+
+host_config = load_hosts_file("fhir_hosts")
+
+# For some reason, the title didn't make it into the FHIR representation of the 
+# research study for the GTEX load
+titles = {
+	"GTEX": "Genotype-Tissue Expression (GTEx)"
+}
+
+Path("output").mkdir(exist_ok=True, parents=True)
+new_filename= "output/patient_details.tsv"
+with open(new_filename, 'wt') as outf:
+	writer = csv.writer(outf, delimiter='\t', quotechar='"')
+
+	writer.writerow([
+		"docref_uri",
+		"tissue_type",
+		"condition_disease",
+		"study_name",
+		"patient_sex"
+	])	
+
+
+	for study in study_order:
+		filename = input[study]
+
+		print(f"Pulling data for {study} from {filename}")
+
+		client = FhirClient(host_config[srvr[study]])
+		with open(filename, 'rt') as f:
+			reader = DictReader(f, delimiter='\t', quotechar='"')
+
+			for line in reader:
+				specuri = line.get("specimen_uri")
+
+				tissue_type=""
+
+				# Not everything has a specimen properly provided at the docref
+				if specuri:
+					id = specuri.split("/")[-1]
+					tissue_type = get_tissue_display(client, f"Specimen/{id}")
+			
+				# We are assuming that there is always a patient (which is currently
+				# a valid assumption)
+				paturi = line.get("patient_uri")
+				id = paturi.split("/")[-1]
+
+				patient_resource = get_resource(client, f"Patient/{id}")
+
+				study_resource = get_study(client, patient_resource)
+
+				study_title = study_resource.get('title')
+
+				if study_title is None:
+					study_title = titles[study]
+
+				# There wasn't sufficient time to deal with the conditions so 
+				# that is going to be an empty string 
+				writer.writerow([
+					line.get("docref_uri"),
+					tissue_type,
+					"",
+					study_title,
+					patient_resource.get("gender")
+				])
+
+


### PR DESCRIPTION
These scripts provide a way to pull data from the 3 repositories and write CSV files. 

pull_fhircat starts by pulling DocumentReferences, filtered on the filename suffixes Robert had identified and then grabs Patient and Specimen resources to fill in the gaps requested in [Issue 11](https://github.com/NIH-NCPI/FHIR-CAT-June22/issues/11) I was in the middle of updating it include additional columns discussed with the rest of the team when I was pulled away (please not it may no longer run due to these changes)

update_data loads a number of FHIR references and populates the 5 columns from Issue 11 in a simple format. 